### PR TITLE
updated to latest version of sqlite3 to fix yarn install on node version 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
   "dependencies": {
     "@keyv/sql": "1.1.2",
     "pify": "3.0.0",
-    "sqlite3": "3.1.13"
+    "sqlite3": "^4.0.2"
   },
   "devDependencies": {
+    "@keyv/test-suite": "*",
     "ava": "^0.25.0",
     "coveralls": "^3.0.0",
     "eslint-config-xo-lukechilds": "^1.0.0",
     "keyv": "*",
-    "@keyv/test-suite": "*",
     "nyc": "^11.0.3",
     "requirable": "^1.0.1",
     "this": "^1.0.2",


### PR DESCRIPTION
Currently keyv/sqlite is broken for node 10.x as the node 10 binaries for sqlite3 are built for 4.x and keyv is dependent on 3