### PR TITLE
fix(package): update sqlite3 to version 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@keyv/sql": "1.1.2",
     "pify": "3.0.0",
-    "sqlite3": "4.0.2"
+    "sqlite3": "4.0.8"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Closes #41. This is essential for Node v12.